### PR TITLE
Move build status markdown to new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# oauth-ios-swift [![Build Status](https://travis-ci.org/feedhenry-templates/oauth-ios-swift.png)](https://travis-ci.org/feedhenry-templates/oauth-ios-swift)
+# oauth-ios-swift
+[![Build Status](https://travis-ci.org/feedhenry-templates/oauth-ios-swift.png)](https://travis-ci.org/feedhenry-templates/oauth-ios-swift)
 
 > Obj-C version is available [here](https://github.com/feedhenry-templates/oauth-ios-app).
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3422

Motivation: Studio cannot convert the markdown if it's on the same line as the header